### PR TITLE
Added optional value to flutter_flow_choice_chips.dart

### DIFF
--- a/lib/src/flutter_flow/flutter_flow_choice_chips.dart
+++ b/lib/src/flutter_flow/flutter_flow_choice_chips.dart
@@ -5,8 +5,9 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 const double _kChoiceChipsHeight = 40.0;
 
 class ChipData {
-  const ChipData(this.label, [this.iconData]);
+  const ChipData(this.label, [this.value = "", this.iconData]);
   final String label;
+  final String value;
   final IconData? iconData;
 }
 
@@ -77,7 +78,8 @@ class _FlutterFlowChoiceChipsState extends State<FlutterFlowChoiceChips> {
         children: [
           ...widget.options.map(
             (option) {
-              final selected = choiceChipValues.contains(option.label);
+              final String value = option.value.isNotEmpty ? option.value : option.label;
+              final selected = choiceChipValues.contains(value);
               final style = selected
                   ? widget.selectedChipStyle
                   : widget.unselectedChipStyle;
@@ -88,13 +90,13 @@ class _FlutterFlowChoiceChipsState extends State<FlutterFlowChoiceChips> {
                   onSelected: (isSelected) {
                     if (isSelected) {
                       widget.multiselect
-                          ? choiceChipValues.add(option.label)
-                          : choiceChipValues = [option.label];
+                          ? choiceChipValues.add(value)
+                          : choiceChipValues = [value];
                       widget.onChanged(choiceChipValues);
                       setState(() {});
                     } else {
                       if (widget.multiselect) {
-                        choiceChipValues.remove(option.label);
+                        choiceChipValues.remove(value);
                         widget.onChanged(choiceChipValues);
                         setState(() {});
                       }


### PR DESCRIPTION
Added option value behind the label. This is a very common usecase for these multichoice widgets especially when working with multiple languages. The label displayed to the user will often be different than what we store as the value. 

For example, when you have a list of enum a user can select - you will translate the enum to string but keep the enum as the value you store